### PR TITLE
new: Support `gofmt` and loosen version range.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### 🚀 Updates
 
 - Added `gofmt` as a secondary export.
+- Updated `go.mod` version parsing to use better ranges.
 
 ## 0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.11.1
+
+#### 🚀 Updates
+
+- Added `gofmt` as a secondary export.
+
 ## 0.11.0
 
 #### 🚀 Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### 🚀 Updates
 
-- Added `gofmt` as a secondary export.
+- Added `gofmt` as a secondary shim/binary.
 - Updated `go.mod` version parsing to use better ranges.
 
 ## 0.11.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "go_plugin"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "extism-pdk",
  "proto_pdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "go_plugin"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -144,6 +144,10 @@ pub fn locate_executables(
         primary: Some(ExecutableConfig::new(
             env.os.get_exe_name(format!("bin/{}", BIN)),
         )),
+        secondary: HashMap::from_iter([(
+            "gofmt".into(),
+            ExecutableConfig::new(env.os.get_exe_name("bin/gofmt")),
+        )]),
         ..LocateExecutablesOutput::default()
     }))
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -52,7 +52,9 @@ pub fn parse_version_file(
     if input.file == "go.mod" || input.file == "go.work" {
         for line in input.content.split('\n') {
             if let Some(v) = line.strip_prefix("go ") {
-                version = Some(UnresolvedVersionSpec::parse(v)?);
+                let range = format!("^{}", from_go_version(v));
+
+                version = Some(UnresolvedVersionSpec::parse(range)?);
                 break;
             }
         }

--- a/tests/snapshots/shims_test__creates_shims.snap
+++ b/tests/snapshots/shims_test__creates_shims.snap
@@ -3,5 +3,9 @@ source: tests/shims_test.rs
 expression: "std::fs::read_to_string(sandbox.path().join(\".proto/shims/registry.json\")).unwrap()"
 ---
 {
-  "go-test": {}
+  "go-test": {},
+  "gofmt": {
+    "alt_bin": true,
+    "parent": "go-test"
+  }
 }

--- a/tests/versions_test.rs
+++ b/tests/versions_test.rs
@@ -5,7 +5,7 @@ generate_resolve_versions_tests!("go-test", {
     "1.11" => "1.11.13",
     "1.9.0-rc2" => "1.9.0-rc2",
     "1.21.0" => "1.21.0",
-    "1.21" => "1.21.9",
+    "1.21" => "1.21.10",
 });
 
 #[test]
@@ -50,7 +50,7 @@ require (
 
     assert_eq!(
         output.version.unwrap(),
-        UnresolvedVersionSpec::parse("1.20").unwrap()
+        UnresolvedVersionSpec::parse("^1.20.0").unwrap()
     );
 }
 
@@ -92,7 +92,7 @@ use (
 
     assert_eq!(
         output.version.unwrap(),
-        UnresolvedVersionSpec::parse("1.18").unwrap()
+        UnresolvedVersionSpec::parse("^1.18.0").unwrap()
     );
 }
 


### PR DESCRIPTION
Fixes https://github.com/moonrepo/go-plugin/issues/24 and https://github.com/moonrepo/go-plugin/issues/23